### PR TITLE
Fix benchmark instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ To read, jump to the `less_slow.rs` source file and read the code snippets and c
 If you are familiar with Rust and want to review code and measurements as you read, you can clone the repository and execute the following commands.
 
 ```sh
-rustup default nightly
-cargo bench
+rustup install nightly-2025-01-11
+cargo +nightly-2025-01-11 bench
 ```


### PR DESCRIPTION
Fix nightly version to prevent this repository from aging and not working again due to unstable nature of nightly-only features.