### PR TITLE
Use nightly toolchain automatically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,5 @@ To read, jump to the `less_slow.rs` source file and read the code snippets and c
 If you are familiar with Rust and want to review code and measurements as you read, you can clone the repository and execute the following commands.
 
 ```sh
-rustup install nightly-2025-01-11
-cargo +nightly-2025-01-11 bench
+cargo bench
 ```

--- a/less_slow.rs
+++ b/less_slow.rs
@@ -170,7 +170,7 @@ const PIPE_END: u64 = 49;
 /// Checks if an integer is a power of two.
 #[inline(always)]
 fn is_power_of_two(x: u64) -> bool {
-    x != 0 && (x & (x - 1)) == 0
+    x.count_ones() == 1
 }
 
 /// Checks if an integer is a power of three.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Adjusted it to be able to just `cargo bench`.

Cargo will install nigthly toolchain if needed.

Bonus: rust-analyzer stops complaining about nightly features.